### PR TITLE
do not draw twice. from both, keep fast draw_idle

### DIFF
--- a/mpl_volume_viewer.py
+++ b/mpl_volume_viewer.py
@@ -98,7 +98,6 @@ class SliceViewer:
         if event.key in KEYMAP:
             f = KEYMAP[event.key]
             f(event, self)
-        fig.canvas.draw()
 
     def process_mouse_button(self, event):
         ax = event.inaxes


### PR DESCRIPTION
Fixes https://github.com/jni/mpl-volume-viewer/issues/7